### PR TITLE
mpich additions for Romio341 refresh

### DIFF
--- a/3rd-party/romio341/adio/ad_gpfs/ad_gpfs.h
+++ b/3rd-party/romio341/adio/ad_gpfs/ad_gpfs.h
@@ -11,11 +11,11 @@
 #ifndef AD_GPFS_H_INCLUDED
 #define AD_GPFS_H_INCLUDED
 
+#include "adio.h"
 #include <unistd.h>
 #include <stdlib.h>
 #include <sys/types.h>
 #include <fcntl.h>
-#include "adio.h"
 
 #ifdef HAVE_SIGNAL_H
 #include <signal.h>

--- a/3rd-party/romio341/adio/ad_gpfs/ad_gpfs_aggrs.c
+++ b/3rd-party/romio341/adio/ad_gpfs/ad_gpfs_aggrs.c
@@ -705,6 +705,7 @@ void ADIOI_GPFS_Calc_others_req(ADIO_File fd, int count_my_req_procs,
         } else {
             others_req[i].count = 0;
             others_req[i].offsets = NULL;
+            others_req[i].mem_ptrs = NULL;
             others_req[i].lens = NULL;
         }
     }

--- a/3rd-party/romio341/adio/ad_gpfs/ad_gpfs_rdcoll.c
+++ b/3rd-party/romio341/adio/ad_gpfs/ad_gpfs_rdcoll.c
@@ -425,8 +425,12 @@ void ADIOI_GPFS_ReadStridedColl(ADIO_File fd, void *buf, int count,
     GPFSMPIO_T_CIO_REPORT(0, fd, myrank, nprocs);
 
     /* free all memory allocated for collective I/O */
-    ADIOI_Free(others_req[0].offsets);
-    ADIOI_Free(others_req[0].mem_ptrs);
+    if (others_req[0].offsets) {
+        ADIOI_Free(others_req[0].offsets);
+    }
+    if (others_req[0].mem_ptrs) {
+        ADIOI_Free(others_req[0].mem_ptrs);
+    }
     ADIOI_Free(others_req);
 
     ADIOI_Free(buf_idx);

--- a/3rd-party/romio341/adio/ad_gpfs/ad_gpfs_wrcoll.c
+++ b/3rd-party/romio341/adio/ad_gpfs/ad_gpfs_wrcoll.c
@@ -447,8 +447,12 @@ void ADIOI_GPFS_WriteStridedColl(ADIO_File fd, const void *buf, int count,
     GPFSMPIO_T_CIO_REPORT(1, fd, myrank, nprocs);
 
     /* free all memory allocated for collective I/O */
-    ADIOI_Free(others_req[0].offsets);
-    ADIOI_Free(others_req[0].mem_ptrs);
+    if (others_req[0].offsets) {
+        ADIOI_Free(others_req[0].offsets);
+    }
+    if (others_req[0].mem_ptrs) {
+        ADIOI_Free(others_req[0].mem_ptrs);
+    }
     ADIOI_Free(others_req);
 
     ADIOI_Free(buf_idx);

--- a/3rd-party/romio341/adio/ad_gpfs/ad_gpfs_wrcoll.c
+++ b/3rd-party/romio341/adio/ad_gpfs/ad_gpfs_wrcoll.c
@@ -360,7 +360,7 @@ void ADIOI_GPFS_WriteStridedColl(ADIO_File fd, const void *buf, int count,
             ADIOI_OneSidedWriteAggregation(fd, offset_list, len_list, contig_access_count, buf,
                                            datatype, error_code, firstFileOffset, lastFileOffset,
                                            currentValidDataIndex, fd_start, fd_end, &holeFound,
-                                           noStripeParms);
+                                           &noStripeParms);
             romio_onesided_no_rmw = prev_romio_onesided_no_rmw;
             GPFSMPIO_T_CIO_REPORT(1, fd, myrank, nprocs);
             ADIOI_Free(offset_list);

--- a/3rd-party/romio341/adio/ad_gpfs/ad_gpfs_wrcoll.c
+++ b/3rd-party/romio341/adio/ad_gpfs/ad_gpfs_wrcoll.c
@@ -1541,7 +1541,7 @@ static void ADIOI_W_Exchange_data_alltoallv(ADIO_File fd, const void *buf, char 
         for (i = 0; i < nprocs; i++) {
             if (send_size[i]) {
                 sbuf_ptr = all_send_buf + sdispls[i];
-                memcpy(sbuf_ptr, buf + buf_idx[i], send_size[i]);
+                memcpy(sbuf_ptr, (char *) buf + buf_idx[i], send_size[i]);
                 buf_idx[i] += send_size[i];
             }
         }

--- a/3rd-party/romio341/adio/ad_lustre/ad_lustre.h
+++ b/3rd-party/romio341/adio/ad_lustre/ad_lustre.h
@@ -9,6 +9,7 @@
 /* temp*/
 #define HAVE_ASM_TYPES_H 1
 
+#include "adio.h"
 #define _GNU_SOURCE 1
 #include <stdlib.h>
 #include <sys/types.h>
@@ -30,7 +31,6 @@
 
 #include <sys/ioctl.h>
 
-#include "adio.h"
 #include "ad_tuning.h"
 
 #ifdef HAVE_LUSTRE_LUSTRE_USER_H

--- a/3rd-party/romio341/adio/ad_lustre/ad_lustre_wrstr.c
+++ b/3rd-party/romio341/adio/ad_lustre/ad_lustre_wrstr.c
@@ -13,7 +13,7 @@
                 ADIO_WriteContig(fd, writebuf, writebuf_len, MPI_BYTE,  \
                                  ADIO_EXPLICIT_OFFSET, writebuf_off,    \
                                  &status1, error_code);                 \
-                if (!(fd->atomicity))                                   \
+                if (!fd->atomicity && fd->hints->ds_write == ADIOI_HINT_DISABLE) \
                     ADIOI_UNLOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
                 if (*error_code != MPI_SUCCESS) {                       \
                     *error_code = MPIO_Err_create_code(*error_code,     \
@@ -30,7 +30,7 @@
             writebuf_len = (unsigned) MPL_MIN(end_offset - writebuf_off + 1, \
                                               (writebuf_off / stripe_size + 1) * \
                                               stripe_size - writebuf_off); \
-            if (!(fd->atomicity))                                       \
+            if (!fd->atomicity && fd->hints->ds_write == ADIOI_HINT_DISABLE) \
                 ADIOI_WRITE_LOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
             ADIO_ReadContig(fd, writebuf, writebuf_len, MPI_BYTE,       \
                             ADIO_EXPLICIT_OFFSET,                       \
@@ -53,7 +53,7 @@
         while (write_sz != req_len) {                                   \
             ADIO_WriteContig(fd, writebuf, writebuf_len, MPI_BYTE,      \
                              ADIO_EXPLICIT_OFFSET, writebuf_off, &status1, error_code); \
-            if (!(fd->atomicity))                                       \
+            if (!fd->atomicity && fd->hints->ds_write == ADIOI_HINT_DISABLE) \
                 ADIOI_UNLOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
             if (*error_code != MPI_SUCCESS) {                           \
                 *error_code = MPIO_Err_create_code(*error_code,         \
@@ -70,7 +70,7 @@
             writebuf_len = (unsigned) MPL_MIN(end_offset - writebuf_off + 1, \
                                               (writebuf_off / stripe_size + 1) * \
                                               stripe_size - writebuf_off); \
-            if (!(fd->atomicity))                                       \
+            if (!fd->atomicity && fd->hints->ds_write == ADIOI_HINT_DISABLE) \
                 ADIOI_WRITE_LOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
             ADIO_ReadContig(fd, writebuf, writebuf_len, MPI_BYTE,       \
                             ADIO_EXPLICIT_OFFSET,                       \
@@ -213,8 +213,9 @@ void ADIOI_LUSTRE_WriteStrided(ADIO_File fd, const void *buf, int count,
         writebuf_off = 0;
         writebuf_len = 0;
 
-        /* if atomicity is true, lock the region to be accessed */
-        if (fd->atomicity)
+        /* if atomicity is true or data sieving is not disable, lock the region
+         * to be accessed */
+        if (fd->atomicity || fd->hints->ds_write != ADIOI_HINT_DISABLE)
             ADIOI_WRITE_LOCK(fd, start_off, SEEK_SET, bufsize);
 
         for (j = 0; j < count; j++) {
@@ -231,7 +232,7 @@ void ADIOI_LUSTRE_WriteStrided(ADIO_File fd, const void *buf, int count,
         ADIO_WriteContig(fd, writebuf, writebuf_len, MPI_BYTE,
                          ADIO_EXPLICIT_OFFSET, writebuf_off, &status1, error_code);
 
-        if (fd->atomicity)
+        if (fd->atomicity || fd->hints->ds_write != ADIOI_HINT_DISABLE)
             ADIOI_UNLOCK(fd, start_off, SEEK_SET, bufsize);
         if (*error_code != MPI_SUCCESS) {
             ADIOI_Free(writebuf);
@@ -311,8 +312,12 @@ void ADIOI_LUSTRE_WriteStrided(ADIO_File fd, const void *buf, int count,
             userbuf_off = 0;
             ADIOI_BUFFERED_WRITE_WITHOUT_READ;
             /* write the buffer out finally */
+            if (fd->hints->ds_write != ADIOI_HINT_DISABLE)
+                ADIOI_WRITE_LOCK(fd, writebuf_off, SEEK_SET, writebuf_len);
             ADIO_WriteContig(fd, writebuf, writebuf_len, MPI_BYTE,
                              ADIO_EXPLICIT_OFFSET, writebuf_off, &status1, error_code);
+            if (fd->hints->ds_write != ADIOI_HINT_DISABLE)
+                ADIOI_UNLOCK(fd, writebuf_off, SEEK_SET, writebuf_len);
 
             if (file_ptr_type == ADIO_INDIVIDUAL) {
                 /* update MPI-IO file pointer to point to the first byte
@@ -362,8 +367,9 @@ void ADIOI_LUSTRE_WriteStrided(ADIO_File fd, const void *buf, int count,
             fwr_size = MPL_MIN(flat_file->blocklens[j], bufsize - i_offset);
         }
 
-/* if atomicity is true, lock the region to be accessed */
-        if (fd->atomicity)
+        /* if atomicity is true or data sieving is not disable, lock the region
+         * to be accessed */
+        if (fd->atomicity || fd->hints->ds_write != ADIOI_HINT_DISABLE)
             ADIOI_WRITE_LOCK(fd, start_off, SEEK_SET, end_offset - start_off + 1);
 
         writebuf_off = 0;
@@ -481,12 +487,12 @@ void ADIOI_LUSTRE_WriteStrided(ADIO_File fd, const void *buf, int count,
         if (writebuf_len) {
             ADIO_WriteContig(fd, writebuf, writebuf_len, MPI_BYTE,
                              ADIO_EXPLICIT_OFFSET, writebuf_off, &status1, error_code);
-            if (!(fd->atomicity))
+            if (!fd->atomicity && fd->hints->ds_write == ADIOI_HINT_DISABLE)
                 ADIOI_UNLOCK(fd, writebuf_off, SEEK_SET, writebuf_len);
             if (*error_code != MPI_SUCCESS)
                 return;
         }
-        if (fd->atomicity)
+        if (fd->atomicity || fd->hints->ds_write != ADIOI_HINT_DISABLE)
             ADIOI_UNLOCK(fd, start_off, SEEK_SET, end_offset - start_off + 1);
 
         ADIOI_Free(writebuf);

--- a/3rd-party/romio341/adio/ad_panfs/ad_panfs.h
+++ b/3rd-party/romio341/adio/ad_panfs/ad_panfs.h
@@ -6,10 +6,10 @@
 #ifndef AD_PANFS_H_INCLUDED
 #define AD_PANFS_H_INCLUDED
 
+#include "adio.h"
 #include <unistd.h>
 #include <sys/types.h>
 #include <fcntl.h>
-#include "adio.h"
 
 #ifndef NO_AIO
 #ifdef AIO_SUN

--- a/3rd-party/romio341/adio/ad_pvfs2/ad_pvfs2_io_dtype.c
+++ b/3rd-party/romio341/adio/ad_pvfs2/ad_pvfs2_io_dtype.c
@@ -3,8 +3,8 @@
  *     See COPYRIGHT in top-level directory
  */
 
-#include <assert.h>
 #include "adio.h"
+#include <assert.h>
 #include "adio_extern.h"
 #include "ad_pvfs2.h"
 #include "ad_pvfs2_io.h"

--- a/3rd-party/romio341/adio/ad_pvfs2/ad_pvfs2_io_list.c
+++ b/3rd-party/romio341/adio/ad_pvfs2/ad_pvfs2_io_list.c
@@ -3,8 +3,8 @@
  *     See COPYRIGHT in top-level directory
  */
 
-#include <assert.h>
 #include "adio.h"
+#include <assert.h>
 #include "adio_extern.h"
 #include "ad_pvfs2.h"
 #include "ad_pvfs2_io.h"

--- a/3rd-party/romio341/adio/ad_xfs/ad_xfs.h
+++ b/3rd-party/romio341/adio/ad_xfs/ad_xfs.h
@@ -6,10 +6,10 @@
 #ifndef AD_XFS_H_INCLUDED
 #define AD_XFS_H_INCLUDED
 
+#include "adio.h"
 #include <unistd.h>
 #include <sys/types.h>
 #include <fcntl.h>
-#include "adio.h"
 
 #if defined(MPISGI)
 #include "xfs/xfs_fs.h"

--- a/3rd-party/romio341/adio/common/ad_darray.c
+++ b/3rd-party/romio341/adio/common/ad_darray.c
@@ -196,6 +196,13 @@ static int MPIOI_Type_block(int *array_of_gsizes, int dim, int ndims, int nprocs
     if (mysize == 0)
         *st_offset = 0;
 
+    MPI_Aint ex;
+    MPI_Type_extent(type_old, &ex);
+    MPI_Datatype type_tmp;
+    MPI_Type_create_resized(*type_new, 0, array_of_gsizes[dim] * ex, &type_tmp);
+    MPI_Type_free(type_new);
+    *type_new = type_tmp;
+
     return MPI_SUCCESS;
 }
 
@@ -292,6 +299,12 @@ static int MPIOI_Type_cyclic(int *array_of_gsizes, int dim, int ndims, int nproc
 
     if (local_size == 0)
         *st_offset = 0;
+
+    MPI_Aint ex;
+    MPI_Type_extent(type_old, &ex);
+    MPI_Type_create_resized(*type_new, 0, array_of_gsizes[dim] * ex, &type_tmp);
+    MPI_Type_free(type_new);
+    *type_new = type_tmp;
 
     return MPI_SUCCESS;
 }

--- a/3rd-party/romio341/adio/common/ad_write_str.c
+++ b/3rd-party/romio341/adio/common/ad_write_str.c
@@ -12,7 +12,8 @@
             if (writebuf_len) {                                         \
                 ADIO_WriteContig(fd, writebuf, writebuf_len, MPI_BYTE,  \
                                  ADIO_EXPLICIT_OFFSET, writebuf_off, &status1, error_code); \
-                if (!(fd->atomicity)) ADIOI_UNLOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
+                if (!fd->atomicity && fd->hints->ds_write == ADIOI_HINT_DISABLE) \
+                    ADIOI_UNLOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
                 if (*error_code != MPI_SUCCESS) {                       \
                     *error_code = MPIO_Err_create_code(*error_code,     \
                                                        MPIR_ERR_RECOVERABLE, myname, \
@@ -23,7 +24,8 @@
             }                                                           \
             writebuf_off = req_off;                                     \
             writebuf_len = (unsigned) (MPL_MIN(max_bufsize,end_offset-writebuf_off+1)); \
-            if (!(fd->atomicity)) ADIOI_WRITE_LOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
+            if (!fd->atomicity && fd->hints->ds_write == ADIOI_HINT_DISABLE) \
+                ADIOI_WRITE_LOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
             ADIO_ReadContig(fd, writebuf, writebuf_len, MPI_BYTE,       \
                             ADIO_EXPLICIT_OFFSET, writebuf_off, &status1, error_code); \
             if (*error_code != MPI_SUCCESS) {                           \
@@ -40,7 +42,8 @@
         while (write_sz != req_len) {                                   \
             ADIO_WriteContig(fd, writebuf, writebuf_len, MPI_BYTE,      \
                              ADIO_EXPLICIT_OFFSET, writebuf_off, &status1, error_code); \
-            if (!(fd->atomicity)) ADIOI_UNLOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
+            if (!fd->atomicity && fd->hints->ds_write == ADIOI_HINT_DISABLE) \
+                ADIOI_UNLOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
             if (*error_code != MPI_SUCCESS) {                           \
                 *error_code = MPIO_Err_create_code(*error_code,         \
                                                    MPIR_ERR_RECOVERABLE, myname, \
@@ -52,7 +55,8 @@
             userbuf_off += write_sz;                                    \
             writebuf_off += writebuf_len;                               \
             writebuf_len = (unsigned) (MPL_MIN(max_bufsize,end_offset-writebuf_off+1)); \
-            if (!(fd->atomicity)) ADIOI_WRITE_LOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
+            if (!fd->atomicity && fd->hints->ds_write == ADIOI_HINT_DISABLE) \
+                ADIOI_WRITE_LOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
             ADIO_ReadContig(fd, writebuf, writebuf_len, MPI_BYTE,       \
                             ADIO_EXPLICIT_OFFSET, writebuf_off, &status1, error_code); \
             if (*error_code != MPI_SUCCESS) {                           \
@@ -184,8 +188,9 @@ void ADIOI_GEN_WriteStrided(ADIO_File fd, const void *buf, int count,
         writebuf = (char *) ADIOI_Malloc(max_bufsize);
         writebuf_len = (unsigned) (MPL_MIN(max_bufsize, end_offset - writebuf_off + 1));
 
-/* if atomicity is true, lock the region to be accessed */
-        if (fd->atomicity)
+        /* if atomicity is true or data sieving is not disable, lock the region
+         * to be accessed */
+        if (fd->atomicity || fd->hints->ds_write != ADIOI_HINT_DISABLE)
             ADIOI_WRITE_LOCK(fd, start_off, SEEK_SET, end_offset - start_off + 1);
 
         for (j = 0; j < count; j++) {
@@ -204,7 +209,7 @@ void ADIOI_GEN_WriteStrided(ADIO_File fd, const void *buf, int count,
                              writebuf_off, &status1, error_code);
         }
 
-        if (fd->atomicity)
+        if (fd->atomicity || fd->hints->ds_write != ADIOI_HINT_DISABLE)
             ADIOI_UNLOCK(fd, start_off, SEEK_SET, end_offset - start_off + 1);
 
         if (*error_code != MPI_SUCCESS)
@@ -280,8 +285,10 @@ void ADIOI_GEN_WriteStrided(ADIO_File fd, const void *buf, int count,
              * datatypes, instead of a count of bytes (which might overflow)
              * Other WriteContig calls in this path are operating on data
              * sieving buffer */
+            ADIOI_WRITE_LOCK(fd, offset, SEEK_SET, bufsize);
             ADIO_WriteContig(fd, buf, count, datatype, ADIO_EXPLICIT_OFFSET,
                              offset, status, error_code);
+            ADIOI_UNLOCK(fd, offset, SEEK_SET, bufsize);
 
             if (file_ptr_type == ADIO_INDIVIDUAL) {
                 /* update MPI-IO file pointer to point to the first byte
@@ -330,8 +337,9 @@ void ADIOI_GEN_WriteStrided(ADIO_File fd, const void *buf, int count,
             fwr_size = MPL_MIN(flat_file->blocklens[j], bufsize - i_offset);
         }
 
-/* if atomicity is true, lock the region to be accessed */
-        if (fd->atomicity)
+        /* if atomicity is true or data sieving is not disable, lock the region
+         * to be accessed */
+        if (fd->atomicity || fd->hints->ds_write != ADIOI_HINT_DISABLE)
             ADIOI_WRITE_LOCK(fd, start_off, SEEK_SET, end_offset - start_off + 1);
 
         writebuf_off = 0;
@@ -451,12 +459,12 @@ void ADIOI_GEN_WriteStrided(ADIO_File fd, const void *buf, int count,
         if (writebuf_len) {
             ADIO_WriteContig(fd, writebuf, writebuf_len, MPI_BYTE, ADIO_EXPLICIT_OFFSET,
                              writebuf_off, &status1, error_code);
-            if (!(fd->atomicity))
+            if (!fd->atomicity && fd->hints->ds_write == ADIOI_HINT_DISABLE)
                 ADIOI_UNLOCK(fd, writebuf_off, SEEK_SET, writebuf_len);
             if (*error_code != MPI_SUCCESS)
                 goto fn_exit;
         }
-        if (fd->atomicity)
+        if (fd->atomicity || fd->hints->ds_write != ADIOI_HINT_DISABLE)
             ADIOI_UNLOCK(fd, start_off, SEEK_SET, end_offset - start_off + 1);
 
         if (file_ptr_type == ADIO_INDIVIDUAL)

--- a/3rd-party/romio341/configure.ac
+++ b/3rd-party/romio341/configure.ac
@@ -68,6 +68,7 @@ AH_TOP([/*
  */
 #ifndef ROMIOCONF_H_INCLUDED
 #define ROMIOCONF_H_INCLUDED
+#include <mplconfig.h>
 
 #include "romioconf-undefs.h"
 ])

--- a/3rd-party/romio341/mpi-io/fortran/deletef.c
+++ b/3rd-party/romio341/mpi-io/fortran/deletef.c
@@ -3,10 +3,10 @@
  *     See COPYRIGHT in top-level directory
  */
 
+#include "adio.h"
 #ifdef _UNICOS
 #include <fortran.h>
 #endif
-#include "adio.h"
 #include "mpio.h"
 
 

--- a/3rd-party/romio341/mpi-io/fortran/get_viewf.c
+++ b/3rd-party/romio341/mpi-io/fortran/get_viewf.c
@@ -3,10 +3,10 @@
  *     See COPYRIGHT in top-level directory
  */
 
+#include "adio.h"
 #ifdef _UNICOS
 #include <fortran.h>
 #endif
-#include "adio.h"
 #include "mpio.h"
 
 

--- a/3rd-party/romio341/mpi-io/fortran/openf.c
+++ b/3rd-party/romio341/mpi-io/fortran/openf.c
@@ -3,10 +3,10 @@
  *     See COPYRIGHT in top-level directory
  */
 
+#include "adio.h"
 #ifdef _UNICOS
 #include <fortran.h>
 #endif
-#include "adio.h"
 #include "mpio.h"
 
 

--- a/3rd-party/romio341/mpi-io/fortran/set_viewf.c
+++ b/3rd-party/romio341/mpi-io/fortran/set_viewf.c
@@ -3,10 +3,10 @@
  *     See COPYRIGHT in top-level directory
  */
 
+#include "adio.h"
 #ifdef _UNICOS
 #include <fortran.h>
 #endif
-#include "adio.h"
 #include "mpio.h"
 
 

--- a/3rd-party/romio341/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/3rd-party/romio341/mpl/src/gpu/mpl_gpu_cuda.c
@@ -3,8 +3,8 @@
  *      See COPYRIGHT in top-level directory.
  */
 
-#include <dlfcn.h>
 #include "mpl.h"
+#include <dlfcn.h>
 #include <assert.h>
 
 #define CUDA_ERR_CHECK(ret) if (unlikely((ret) != cudaSuccess)) goto fn_fail


### PR DESCRIPTION
This is a batch of romio fixes from OMPI that we've contributed back to mpich main.  It's from the time period after we stopped fixing things in our copy of romio and instead started fixing them over in actual mpich romio.

At the time of this PR the below fixes from us have all been accepted into mpich main, but haven't yet appeared in numbered releases like romio 3.4.1.

This is meant to be an add-on to the romio 3.4.1 refresh by @ggouaillardet 
https://github.com/open-mpi/ompi/pull/8740

```
 *  https://github.com/pmodels/mpich/pull/4943
    -- darray fix which contains a flatten fix
        73a3eba
        c4b5762
 *  https://github.com/pmodels/mpich/pull/4995
    -- write strided fix
        bbb5210
 *  https://github.com/pmodels/mpich/pull/5100
    -- build fix for -Wpedantic
        ad0e435
 *  https://github.com/pmodels/mpich/pull/5099
    -- build fix, they had let file-system=...gpfs bit rot
        e1d42af
        313289a
        83bbb82
 *  https://github.com/pmodels/mpich/pull/5150
    -- build fix, configure-related _GNU_SOURCE
        a712b56
        5a036e7
 *  https://github.com/pmodels/mpich/pull/5184
    -- build fix, continuation of _GNU_SOURCE fix
        d97c4ee
```