### PR TITLE
romio341: continuation of modernize MPICH 3.4.1 romio

### DIFF
--- a/3rd-party/romio341/adio/common/ad_darray.c
+++ b/3rd-party/romio341/adio/common/ad_darray.c
@@ -196,8 +196,8 @@ static int MPIOI_Type_block(int *array_of_gsizes, int dim, int ndims, int nprocs
     if (mysize == 0)
         *st_offset = 0;
 
-    MPI_Aint ex;
-    MPI_Type_extent(type_old, &ex);
+    MPI_Aint lb, ex;
+    MPI_Type_get_extent(type_old, &ex);
     MPI_Datatype type_tmp;
     MPI_Type_create_resized(*type_new, 0, array_of_gsizes[dim] * ex, &type_tmp);
     MPI_Type_free(type_new);
@@ -300,8 +300,8 @@ static int MPIOI_Type_cyclic(int *array_of_gsizes, int dim, int ndims, int nproc
     if (local_size == 0)
         *st_offset = 0;
 
-    MPI_Aint ex;
-    MPI_Type_extent(type_old, &ex);
+    MPI_Aint lb, ex;
+    MPI_Type_get_extent(type_old, &ex);
     MPI_Type_create_resized(*type_new, 0, array_of_gsizes[dim] * ex, &type_tmp);
     MPI_Type_free(type_new);
     *type_new = type_tmp;


### PR DESCRIPTION
The official mpich romio PRs I checked into included old-style
MPI calls, so those needed modernized same as an earlier
commit.  I do think both of the modernize PRs could be put
into mpich.

Signed-off-by: Mark Allen <markalle@us.ibm.com>